### PR TITLE
Use standard colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ Usage Options
   
 Configuration
 ---
-  - Highlight colours and other options can be configured in SBSCompare.sublime-settings
-  - Hotkeys can be changed in the included `Default (PLATFORM).sublime-keys` files
-  - To access: *Preferences -> Package Settings -> Compare Side-By-Side*
+  - The standard diff scopes/colors are used, these are
+    `diff.inserted.sbs-compare`, `diff.inserted.char.sbs-compare`,
+    `diff.deleted.sbs-compare`, `diff.deleted.char.sbs-compare`.
+    Note that I just added the suffix ".sbs-compare" to them.
+    You can change the colors in your color scheme (ctrl+shift+P,
+    "UI: Customize Color Scheme").
+  - Other options can be configured in SBSCompare.sublime-settings
+    To access: *Preferences -> Package Settings -> Compare Side-By-Side*
 
 License & Contributing
 ---


### PR DESCRIPTION
Since Sublime ships with the basic git support, it also has a diffing feature and with it defines standard colors for inserted/deleted lines or (intra-line) chars.

We have `diff.inserted` and `diff.inserted.char` usually in green and `diff.deleted` in red.  Every color scheme should already define them. User can change their scheme as usual and change the colors to their liking.

Note that I add the suffix `.sbs-compare` to the scopes (e.g. `diff.inserted.sbs-compare`) so users can also target exactly our scopes.

Closes #4