### PR TITLE
more informative error msg

### DIFF
--- a/sbs_compare.py
+++ b/sbs_compare.py
@@ -130,7 +130,7 @@ class sbs_compare_files(sublime_plugin.ApplicationCommand):
         A = os.path.abspath(A)
         B = os.path.abspath(B)
         if not os.path.isfile(A) or not os.path.isfile(B):
-            print('Compare Error: file(s) not found')
+            print('Compare Error: file(s) not found: %s, %s' % (A, B))
             return
 
         sbs_files = [A, B]


### PR DESCRIPTION
I agree with your changes to the README code -- I looked for a way to get the absolute file path from within Sublime's API, but couldn't find any. It seems like it needs to be handled in the shell function. Here's a very small change to give the user a clue as to why this might be failing from the command line, e.g. if the error message gives `/opt/sublime_text/filename.txt`.